### PR TITLE
doc(readme): style option lang in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ const MagicVueSFC = createVueSFC({
   },
   styles: [
     {
+      lang: 'scss', // scss | less | ts
       content: `.text {
   color: red;
 }`,


### PR DESCRIPTION
Example of adding the lang attribute to readme https://github.com/Tahul/sfc-composer/issues/1